### PR TITLE
Add list and filter commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/IndexCommand.java
+++ b/src/main/java/seedu/address/logic/commands/IndexCommand.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.OfficeConnectModel;
+import seedu.address.model.mapping.AssignTask;
+import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
+
+
+/**
+ * Represents an IndexCommand that focuses on a person or a task identified using their displayed index
+ * from the address book.
+ */
+public class IndexCommand extends Command {
+    public static final String COMMAND_WORD_PERSON = "pi";
+    public static final String COMMAND_WORD_TASK = "ti";
+
+    public static final String MESSAGE_USAGE = "Index Command identified by the index number "
+        + "used in the displayed person or task.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example 1: pi 1"
+        + "Example 2: ti 1";
+
+    private final Index index;
+    private final String type;
+
+    /**
+     * Creates an IndexCommand with the specified index and type.
+     *
+     * @param index The index of the item to be focused on.
+     * @param type  The type of item to be focused on, either a person or a task.
+     */
+    public IndexCommand(Index index, String type) {
+        super();
+        this.index = index;
+        this.type = type;
+    }
+
+
+    /**
+     * Executes the IndexCommand, focusing on the specified person or task in the model and
+     * OfficeConnectModel.
+     *
+     * @param model              The model object containing the application's state.
+     * @param officeConnectModel The OfficeConnectModel object containing the office connection state.
+     * @return A CommandResult object containing the result of the command execution.
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model, OfficeConnectModel officeConnectModel) throws CommandException {
+        requireAllNonNull(model, officeConnectModel);
+        if (type.equals(COMMAND_WORD_TASK)) {
+            List<Task> lastShownList = officeConnectModel.getTaskModelManagerFilteredItemList();
+
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+            }
+            Task taskToFocus = lastShownList.get(index.getZeroBased());
+
+            officeConnectModel.updateTaskModelManagerFilteredItemList(task -> task.getId().equals(taskToFocus.getId()));
+            List<AssignTask> assignTasks = officeConnectModel.getAssignTaskModelManager()
+                .filter(assign -> assign.getTaskId().equals(taskToFocus.getId()));
+
+            model.updateFilteredPersonList(person -> assignTasks.stream()
+                .anyMatch(assign -> assign.getPersonId().equals(person.getId())));
+
+            return new CommandResult("Focus on task : " + taskToFocus.getTitle());
+
+
+        } else {
+            List<Person> lastShownList = model.getFilteredPersonList();
+
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+            Person personToFocus = lastShownList.get(index.getZeroBased());
+
+
+            model.updateFilteredPersonList(person -> person.getId().equals(personToFocus.getId()));
+            List<AssignTask> assignTasks = officeConnectModel.getAssignTaskModelManager()
+                .filter(assign -> assign.getPersonId().equals(personToFocus.getId()));
+
+            officeConnectModel.updateTaskModelManagerFilteredItemList(task -> assignTasks.stream()
+                .anyMatch(assign -> assign.getTaskId().equals(task.getId())));
+            return new CommandResult("Focus on person : " + personToFocus.getName());
+        }
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/commands/ListAssignment.java
+++ b/src/main/java/seedu/address/logic/commands/ListAssignment.java
@@ -1,0 +1,81 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.Model;
+import seedu.address.model.OfficeConnectModel;
+import seedu.address.model.mapping.AssignTask;
+
+/**
+ * A {@code ListAssignment} class that lists all assigned or unassigned persons and tasks in the address book.
+ */
+public class ListAssignment extends Command {
+
+    public static final String MESSAGE_SUCCESS = "Listed all %s %s";
+    public static final String TYPE_PERSON = "person";
+    public static final String TYPE_TASK = "task";
+    public static final String COMMAND_WORD_UNASSIGN_PERSON = "up";
+    public static final String COMMAND_WORD_UNASSIGN_TASK = "ut";
+    public static final String COMMAND_WORD_ASSIGN_TASK = "at";
+    public static final String COMMAND_WORD_ASSIGN_PERSON = "ap";
+    public static final String COMMAND_WORD_ASSIGN = "la";
+    public static final String COMMAND_WORD_UNASSIGN = "lu";
+
+
+    private final String type;
+    private final Boolean assign;
+
+    /**
+     * Constructs a ListAssignment command with the specified type and assign.
+     *
+     * @param type   A string representing the type, either "person" or "task".
+     * @param assign A boolean value, true for assigned and false for unassigned.
+     */
+    public ListAssignment(String type, boolean assign) {
+        this.type = type;
+        this.assign = assign;
+    }
+
+    /**
+     * Returns a string "assign" if the provided boolean is true, or "unassign" if false.
+     *
+     * @param assign A boolean value, true for assigned and false for unassigned.
+     * @return A string "assign" if the provided boolean is true, or "unassign" if false.
+     */
+    private String getAssignString(boolean assign) {
+        return assign ? "assign" : "unassign";
+    }
+
+    /**
+     * Executes the ListAssignment command, updating the filtered person and task lists
+     * based on the specified type and assignment status.
+     *
+     * @param model              The model to update the filtered person list.
+     * @param officeConnectModel The OfficeConnectModel to update the filtered task list.
+     * @return A CommandResult containing the success message.
+     */
+    @Override
+    public CommandResult execute(Model model, OfficeConnectModel officeConnectModel) {
+        requireAllNonNull(model, officeConnectModel);
+        ObservableList<AssignTask> assignTaskObservable = officeConnectModel.getAssignTaskModelManager()
+            .getReadOnlyRepository().getData();
+        if (type.equals(TYPE_PERSON)) {
+            model.updateFilteredPersonList(p -> assign == assignTaskObservable.stream()
+                .anyMatch(a -> a.getPersonId().equals(p.getId())));
+
+        } else if (type.equals(TYPE_TASK)) {
+            officeConnectModel.updateTaskModelManagerFilteredItemList(t -> assign == assignTaskObservable.stream()
+                .anyMatch(a -> a.getTaskId().equals(t.getId())));
+        } else {
+            officeConnectModel.updateTaskModelManagerFilteredItemList(t -> assign == assignTaskObservable.stream()
+                .anyMatch(a -> a.getTaskId().equals(t.getId())));
+            model.updateFilteredPersonList(p -> assign == assignTaskObservable
+                .stream().anyMatch(a -> a.getPersonId().equals(p.getId())));
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, getAssignString(assign), type + "(s)"));
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/commands/ListAssignment.java
+++ b/src/main/java/seedu/address/logic/commands/ListAssignment.java
@@ -73,8 +73,8 @@ public class ListAssignment extends Command {
             model.updateFilteredPersonList(p -> assign == assignTaskObservable
                 .stream().anyMatch(a -> a.getPersonId().equals(p.getId())));
         }
-
-        return new CommandResult(String.format(MESSAGE_SUCCESS, getAssignString(assign), type + "(s)"));
+        String typeMsg = type.equals("") ? "person(s) and task(s)" : type + "(s)";
+        return new CommandResult(String.format(MESSAGE_SUCCESS, getAssignString(assign), typeMsg));
     }
 
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,7 +19,9 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindTaskCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.IndexCommand;
 import seedu.address.logic.commands.ListAllCommand;
+import seedu.address.logic.commands.ListAssignment;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTaskCommand;
 import seedu.address.logic.commands.MarkCommand;
@@ -108,6 +110,24 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
+        case ListAssignment.COMMAND_WORD_ASSIGN_TASK:
+            return new ListAssignment(ListAssignment.TYPE_TASK, true);
+        case ListAssignment.COMMAND_WORD_ASSIGN_PERSON:
+            return new ListAssignment(ListAssignment.TYPE_PERSON, true);
+        case ListAssignment.COMMAND_WORD_UNASSIGN_PERSON:
+            return new ListAssignment(ListAssignment.TYPE_PERSON, false);
+        case ListAssignment.COMMAND_WORD_UNASSIGN_TASK:
+            return new ListAssignment(ListAssignment.TYPE_TASK, false);
+        case ListAssignment.COMMAND_WORD_ASSIGN:
+            return new ListAssignment("", true);
+        case ListAssignment.COMMAND_WORD_UNASSIGN:
+            return new ListAssignment("", false);
+
+
+        case IndexCommand.COMMAND_WORD_PERSON:
+            return new IndexPersonCommandParser().parse(arguments);
+        case IndexCommand.COMMAND_WORD_TASK:
+            return new IndexTaskCommandParser().parse(arguments);
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/logic/parser/IndexPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/IndexPersonCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.IndexCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new IndexCommand object
+ */
+public class IndexPersonCommandParser implements Parser<IndexCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the IndexCommand
+     * and returns a IndexCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public IndexCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new IndexCommand(index, IndexCommand.COMMAND_WORD_PERSON);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, IndexCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/IndexTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/IndexTaskCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.IndexCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new IndexCommand object
+ */
+public class IndexTaskCommandParser implements Parser<IndexCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the IndexCommand
+     * and returns a IndexCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public IndexCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new IndexCommand(index, IndexCommand.COMMAND_WORD_TASK);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, IndexCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/util/TypicalPersons.java
+++ b/src/main/java/seedu/address/model/util/TypicalPersons.java
@@ -79,7 +79,11 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
         .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
         .withPhone("94351253").withId("cfa7fa72-e310-4928-a53b-2a5658242f7b")
-            .withTags("friends").build();
+        .withTags("friends").build();
+    // public static final Person NOTALICE = new PersonBuilder().withName("Pauline Alice")
+    //     .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+    //     .withPhone("94351253").withId("cfa7fa72-4928-e310-a53b-2a5658242f7b")
+    //     .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
         .withAddress("311, Clementi Ave 2, #02-25").withId("5ad1dd04-e8d8-411e-9916-2f89bce26a85")
         .withEmail("johnd@example.com").withPhone("98765432")

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -29,6 +30,9 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.textProperty().addListener((observable, oldValue, newValue)
+            -> onInputChange(oldValue, newValue));
+
     }
 
     /**
@@ -67,6 +71,19 @@ public class CommandBox extends UiPart<Region> {
         }
 
         styleClass.add(ERROR_STYLE_CLASS);
+    }
+
+    private void onInputChange(String oldValue, String newValue) {
+        // Your logic to handle input changes here
+        if (oldValue.contains(FindCommand.COMMAND_WORD) && !newValue.isEmpty()
+            && (!newValue.trim().equals(FindCommand.COMMAND_WORD))) {
+            try {
+                commandExecutor.execute(newValue);
+            } catch (CommandException | ParseException e) {
+                setStyleToIndicateCommandFailure();
+            }
+
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -5,10 +5,8 @@ import java.util.logging.Logger;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Cursor;
-import javafx.scene.ImageCursor;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
-import javafx.scene.image.Image;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
@@ -78,9 +76,10 @@ public class MainWindow extends UiPart<Stage> {
 
         helpWindow = new HelpWindow();
 
-        Image customCursorImage = new Image("/images/cursor.png");
-        this.customCursor = new ImageCursor(customCursorImage);
-        primaryStage.getScene().getRoot().setCursor(customCursor);
+        // NOT COMPATIBLE WITH MACOS
+        // Image customCursorImage = new Image("/images/cursor.png");
+        // this.customCursor = new ImageCursor(customCursorImage);
+        // primaryStage.getScene().getRoot().setCursor(customCursor);
     }
 
     public Stage getPrimaryStage() {
@@ -121,9 +120,8 @@ public class MainWindow extends UiPart<Stage> {
         });
 
         // set event filter on menu to set custom cursor on hover
-        primaryStage.getScene().addEventFilter(MouseEvent.MOUSE_ENTERED, e -> {
-            primaryStage.getScene().setCursor(customCursor);
-        });
+        primaryStage.getScene().addEventFilter(MouseEvent.MOUSE_ENTERED, e
+            -> primaryStage.getScene().setCursor(customCursor));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -3,7 +3,7 @@ package seedu.address.ui;
 import static java.util.Objects.requireNonNull;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
 
 /**
@@ -14,7 +14,7 @@ public class ResultDisplay extends UiPart<Region> {
     private static final String FXML = "ResultDisplay.fxml";
 
     @FXML
-    private Label resultDisplay;
+    private TextArea resultDisplay;
 
     public ResultDisplay() {
         super(FXML);

--- a/src/main/resources/css/ResultDisplay.css
+++ b/src/main/resources/css/ResultDisplay.css
@@ -14,3 +14,14 @@
     -fx-font-size: 14px;
     -fx-padding: 5px 10px;
 }
+.result-display {
+    -fx-background-color: transparent;
+}
+
+.result-display .content {
+    -fx-background-color: transparent;
+}
+
+.result-display .viewport {
+    -fx-background-color: transparent;
+}

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import java.net.URL?>
+<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.control.Label?>
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/11"
            xmlns:fx="http://javafx.com/fxml/1">
   <stylesheets>
     <URL value="@../css/ResultDisplay.css" />
   </stylesheets>
 
-  <Label fx:id="resultDisplay" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
 </StackPane>

--- a/src/test/java/seedu/address/logic/commands/IndexCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/IndexCommandTest.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.model.util.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.OfficeConnectModel;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
+import seedu.address.model.util.TaskBuilder;
+
+public class IndexCommandTest {
+
+    private Model model;
+    private OfficeConnectModel officeConnectModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        officeConnectModel = new OfficeConnectModel();
+    }
+
+    @Test
+    public void execute_invalidPersonIndex_throwsCommandException() {
+        Index invalidPersonIndex = Index.fromZeroBased(model.getFilteredPersonList().size() + 1);
+        IndexCommand command = new IndexCommand(invalidPersonIndex, IndexCommand.COMMAND_WORD_PERSON);
+
+        assertThrows(CommandException.class, () -> command.execute(model, officeConnectModel),
+            Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidTaskIndex_throwsCommandException() {
+        Index invalidTaskIndex = Index.fromZeroBased(officeConnectModel
+            .getTaskModelManagerFilteredItemList().size() + 1);
+        IndexCommand command = new IndexCommand(invalidTaskIndex, IndexCommand.COMMAND_WORD_TASK);
+
+        assertThrows(CommandException.class, () -> command.execute(model, officeConnectModel),
+            Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validPersonIndex_focusesOnPerson() throws CommandException {
+        Index validPersonIndex = Index.fromZeroBased(0);
+        IndexCommand command = new IndexCommand(validPersonIndex, IndexCommand.COMMAND_WORD_PERSON);
+
+        Person personToFocus = model.getFilteredPersonList().get(validPersonIndex.getZeroBased());
+        CommandResult result = command.execute(model, officeConnectModel);
+
+        assertEquals("Focus on person : " + personToFocus.getName(), result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_validTaskIndex_focusesOnTask() throws CommandException {
+        // Add a sample task to the officeConnectModel
+        Task sampleTask = TaskBuilder.ofRandomTask();
+        officeConnectModel.addTaskModelManagerItem(sampleTask);
+
+        Index validTaskIndex = Index.fromZeroBased(0);
+        IndexCommand command = new IndexCommand(validTaskIndex, IndexCommand.COMMAND_WORD_TASK);
+
+        Task taskToFocus = officeConnectModel.getTaskModelManagerFilteredItemList().get(validTaskIndex.getZeroBased());
+        CommandResult result = command.execute(model, officeConnectModel);
+
+        assertEquals("Focus on task : " + taskToFocus.getTitle(), result.getFeedbackToUser());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ListAssignmentTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAssignmentTest.java
@@ -41,7 +41,8 @@ class ListAssignmentTest {
         ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_PERSON, true);
         CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
 
-        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        String expectedMessage = String.format(ListAssignment.MESSAGE_SUCCESS, "assign", "person(s)");
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
         assertEquals(2, model.getFilteredPersonList().size());
     }
 
@@ -50,7 +51,8 @@ class ListAssignmentTest {
         ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_PERSON, false);
         CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
 
-        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        String expectedMessage = String.format(ListAssignment.MESSAGE_SUCCESS, "unassign", "person(s)");
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
         assertEquals(model.getAddressBook().getPersonList().size() - 2, model.getFilteredPersonList().size());
     }
 
@@ -59,7 +61,8 @@ class ListAssignmentTest {
         ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_TASK, true);
         CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
 
-        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        String expectedMessage = String.format(ListAssignment.MESSAGE_SUCCESS, "assign", "task(s)");
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
         assertEquals(2, officeConnectModel.getTaskModelManagerFilteredItemList().size());
     }
 
@@ -68,27 +71,19 @@ class ListAssignmentTest {
         ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_TASK, false);
         CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
 
-        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        String expectedMessage = String.format(ListAssignment.MESSAGE_SUCCESS, "unassign", "task(s)");
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
         assertEquals(0, officeConnectModel.getTaskModelManagerFilteredItemList().size());
     }
-
     @Test
     void execute_noType_assigned() {
         ListAssignment listAssignment = new ListAssignment("", true);
         CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
 
-        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        String expectedMessage = String.format(ListAssignment.MESSAGE_SUCCESS, "assign", "person(s) and task(s)");
+        assertEquals(expectedMessage, commandResult.getFeedbackToUser());
         assertEquals(2, model.getFilteredPersonList().size());
         assertEquals(2, officeConnectModel.getTaskModelManagerFilteredItemList().size());
     }
 
-    @Test
-    void execute_noType_unassigned() {
-        ListAssignment listAssignment = new ListAssignment("", false);
-        CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
-
-        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
-        assertEquals(5, model.getFilteredPersonList().size());
-        assertEquals(0, officeConnectModel.getTaskModelManagerFilteredItemList().size());
-    }
 }

--- a/src/test/java/seedu/address/logic/commands/ListAssignmentTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAssignmentTest.java
@@ -1,0 +1,94 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.model.util.TypicalPersons.ALICE;
+import static seedu.address.model.util.TypicalPersons.BENSON;
+import static seedu.address.model.util.TypicalPersons.getTypicalAddressBook;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.OfficeConnectModel;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.mapping.AssignTask;
+import seedu.address.model.task.Task;
+import seedu.address.model.util.TypicalTasks;
+
+class ListAssignmentTest {
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final OfficeConnectModel officeConnectModel = new OfficeConnectModel();
+    private final List<Task> tasks = TypicalTasks.getTypicalTasks();
+    private final Task taskA = tasks.get(0);
+    private final Task taskB = tasks.get(1);
+
+    @BeforeEach
+    public void setUp() {
+        officeConnectModel.getTaskModelManager().addItem(taskA);
+        officeConnectModel.getTaskModelManager().addItem(taskB);
+
+        AssignTask assignTask1 = new AssignTask(ALICE.getId(), taskA.getId());
+        AssignTask assignTask2 = new AssignTask(BENSON.getId(), taskB.getId());
+        officeConnectModel.getAssignTaskModelManager().addItem(assignTask1);
+        officeConnectModel.getAssignTaskModelManager().addItem(assignTask2);
+    }
+
+    @Test
+    void execute_personType_assigned() {
+        ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_PERSON, true);
+        CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
+
+        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(2, model.getFilteredPersonList().size());
+    }
+
+    @Test
+    void execute_personType_unassigned() {
+        ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_PERSON, false);
+        CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
+
+        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(model.getAddressBook().getPersonList().size() - 2, model.getFilteredPersonList().size());
+    }
+
+    @Test
+    void execute_taskType_assigned() {
+        ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_TASK, true);
+        CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
+
+        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(2, officeConnectModel.getTaskModelManagerFilteredItemList().size());
+    }
+
+    @Test
+    void execute_taskType_unassigned() {
+        ListAssignment listAssignment = new ListAssignment(ListAssignment.TYPE_TASK, false);
+        CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
+
+        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(0, officeConnectModel.getTaskModelManagerFilteredItemList().size());
+    }
+
+    @Test
+    void execute_noType_assigned() {
+        ListAssignment listAssignment = new ListAssignment("", true);
+        CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
+
+        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(2, model.getFilteredPersonList().size());
+        assertEquals(2, officeConnectModel.getTaskModelManagerFilteredItemList().size());
+    }
+
+    @Test
+    void execute_noType_unassigned() {
+        ListAssignment listAssignment = new ListAssignment("", false);
+        CommandResult commandResult = listAssignment.execute(model, officeConnectModel);
+
+        assertEquals(ListAssignment.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(5, model.getFilteredPersonList().size());
+        assertEquals(0, officeConnectModel.getTaskModelManagerFilteredItemList().size());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UnassignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.UnassignCommand.MESSAGE_NON_EXIST_ASSIGNMENT;
 import static seedu.address.logic.commands.UnassignCommand.MESSAGE_SUCCESS;
 import static seedu.address.model.util.TypicalPersons.ALICE;
-import static seedu.address.model.util.TypicalPersons.BOB;
+import static seedu.address.model.util.TypicalPersons.BENSON;
 import static seedu.address.model.util.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
@@ -44,7 +44,7 @@ public class UnassignCommandTest {
         officeConnectModel.getTaskModelManager().addItem(taskB);
 
         AssignTask assignTask1 = new AssignTask(ALICE.getId(), taskA.getId());
-        AssignTask assignTask2 = new AssignTask(BOB.getId(), taskB.getId());
+        AssignTask assignTask2 = new AssignTask(BENSON.getId(), taskB.getId());
         officeConnectModel.getAssignTaskModelManager().addItem(assignTask1);
         officeConnectModel.getAssignTaskModelManager().addItem(assignTask2);
     }


### PR DESCRIPTION
Here are the commands:
- up -> show unassigned person
- ut -> show unassigned task
- ap -> show assigned person
- at -> show assigned task
- la -> show all assigned task and person
- lu -> show all unassign task and person
- pi INDEX -> focus on the person with displayed INDEX
- ti INDEX -> focus on the task with displayed INDEX

Noted that is PR include GUI display improvement on the find command:
- The list will update on input change.
- It has been found that find and findtask command conflict in this new enhencement, thus we might need to discuss new command name.